### PR TITLE
Validator Update - Minor - v2.4.0

### DIFF
--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -16,7 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.3.2"
+__version__ = "2.4.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/detection/utils/config.py
+++ b/detection/utils/config.py
@@ -117,11 +117,18 @@ def add_args(cls, parser):
         )
 
         parser.add_argument(
-            "--neuron.timeout",
+            "--neuron.timeout_300",
             type=int,
             help="Timeout",
             default=20,
-        )        
+        )
+
+        parser.add_argument(
+            "--neuron.timeout_10",
+            type=int,
+            help="Timeout",
+            default=2,
+        )
 
         parser.add_argument(
             "--neuron.disable_set_weights",

--- a/detection/utils/config.py
+++ b/detection/utils/config.py
@@ -117,17 +117,10 @@ def add_args(cls, parser):
         )
 
         parser.add_argument(
-            "--neuron.timeout_300",
+            "--neuron.timeout",
             type=int,
             help="Timeout",
             default=20,
-        )
-
-        parser.add_argument(
-            "--neuron.timeout_10",
-            type=int,
-            help="Timeout",
-            default=2,
         )
 
         parser.add_argument(

--- a/detection/validator/forward.py
+++ b/detection/validator/forward.py
@@ -28,7 +28,7 @@ from typing import List
 import torch
 
 
-async def get_all_responces(self, axons, texts, step=35):
+async def get_all_responses(self, axons, texts, timeout, step=35):
     all_responses = []
     for i in range(0, len(axons), step):
         bt.logging.info(f"Sending challenges to the #{i} subset of miners with size {step}")
@@ -38,7 +38,7 @@ async def get_all_responces(self, axons, texts, step=35):
             axons=subset_axons,
             synapse=TextSynapse(texts=texts, predictions=[]),
             deserialize=True,
-            timeout=self.config.neuron.timeout,
+            timeout=timeout,
         )
 
         # Log the results for monitoring purposes.
@@ -74,8 +74,8 @@ async def forward(self):
 
     cnt_challenges_for_check = random.randint(1, min(10, len(texts)))
     check_ids = np.random.choice(np.arange(len(texts)), size=cnt_challenges_for_check, replace=False)
-    check_responses = await get_all_responces(self, axons, texts[check_ids])
-    all_responses = await get_all_responces(self, axons, texts)
+    check_responses = await get_all_responses(self, axons, texts[check_ids], self.config.neuron.timeout_10)
+    all_responses = await get_all_responses(self, axons, texts, self.config.neuron.timeout_300)
 
     rewards, metrics = get_rewards(self, labels=labels, responses=all_responses, check_responses=check_responses, check_ids=check_ids)
     bt.logging.info("Miner uids: {}".format(miner_uids))

--- a/detection/validator/forward.py
+++ b/detection/validator/forward.py
@@ -73,7 +73,7 @@ async def forward(self):
     bt.logging.info(f"Time to generate challenges: {int(end_time - start_time)}")
 
     cnt_challenges_for_check = random.randint(1, min(10, len(texts)))
-    check_ids = np.random.choice(np.arange(len(texts)), size=cnt_challenges_for_check, replace=False)
+    check_ids = np.random.choice(np.arange(len(texts)).astype(int), size=cnt_challenges_for_check, replace=False)
     check_responses = await get_all_responses(self, axons, texts[check_ids], self.config.neuron.timeout)
     all_responses = await get_all_responses(self, axons, texts, self.config.neuron.timeout)
 

--- a/detection/validator/forward.py
+++ b/detection/validator/forward.py
@@ -74,8 +74,8 @@ async def forward(self):
 
     cnt_challenges_for_check = random.randint(1, min(10, len(texts)))
     check_ids = np.random.choice(np.arange(len(texts)), size=cnt_challenges_for_check, replace=False)
-    check_responses = await get_all_responses(self, axons, texts[check_ids], self.config.neuron.timeout_10)
-    all_responses = await get_all_responses(self, axons, texts, self.config.neuron.timeout_300)
+    check_responses = await get_all_responses(self, axons, texts[check_ids], self.config.neuron.timeout)
+    all_responses = await get_all_responses(self, axons, texts, self.config.neuron.timeout)
 
     rewards, metrics = get_rewards(self, labels=labels, responses=all_responses, check_responses=check_responses, check_ids=check_ids)
     bt.logging.info("Miner uids: {}".format(miner_uids))

--- a/detection/validator/forward.py
+++ b/detection/validator/forward.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
- # Copyright © 2024 It's AI 
- 
+ # Copyright © 2024 It's AI
+import random
+
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
@@ -16,6 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import bittensor as bt
+import numpy as np
 
 from detection.protocol import TextSynapse
 from detection.validator.reward import get_rewards
@@ -24,6 +26,26 @@ from detection.utils.uids import get_random_uids
 import time
 from typing import List
 import torch
+
+
+async def get_all_responces(self, axons, texts, step=35):
+    all_responses = []
+    for i in range(0, len(axons), step):
+        bt.logging.info(f"Sending challenges to the #{i} subset of miners with size {step}")
+        subset_axons = axons[i:i + step]
+
+        responses: List[TextSynapse] = await self.dendrite(
+            axons=subset_axons,
+            synapse=TextSynapse(texts=texts, predictions=[]),
+            deserialize=True,
+            timeout=self.config.neuron.timeout,
+        )
+
+        # Log the results for monitoring purposes.
+        bt.logging.info(f"Received responses: {len(responses)}")
+        all_responses.extend(responses)
+        bt.logging.info(f"Overall amount of responses: {len(all_responses)}")
+    return all_responses
 
 
 async def forward(self):
@@ -50,27 +72,12 @@ async def forward(self):
     end_time = time.time()
     bt.logging.info(f"Time to generate challenges: {int(end_time - start_time)}")
 
-    step = 35
-    # Use range() to generate indices from 0 to len(axons), stepping by 'step'
-    all_responses = []
-    for i in range(0, len(axons), step):
-        bt.logging.info(f"Sending challenges to the #{i} subset of miners with size {step}")
-        subset_axons = axons[i:i+step]
+    cnt_challenges_for_check = random.randint(1, min(10, len(texts)))
+    check_ids = np.random.choice(np.arange(len(texts)), size=cnt_challenges_for_check, replace=False)
+    check_responses = await get_all_responces(self, axons, texts[check_ids])
+    all_responses = await get_all_responces(self, axons, texts)
 
-        responses: List[TextSynapse] = await self.dendrite(
-            axons=subset_axons,
-            synapse=TextSynapse(texts=texts, predictions=[]),
-            deserialize=True,
-            timeout=self.config.neuron.timeout,
-        )
-
-        # Log the results for monitoring purposes.
-        bt.logging.info(f"Received responses: {len(responses)}")
-        all_responses.extend(responses)
-        bt.logging.info(f"Overall amount of responses: {len(all_responses)}")
-
-    # Adjust the scores based on responses from miners.
-    rewards, metrics = get_rewards(self, labels=labels, responses=all_responses)
+    rewards, metrics = get_rewards(self, labels=labels, responses=all_responses, check_responses=check_responses, check_ids=check_ids)
     bt.logging.info("Miner uids: {}".format(miner_uids))
     bt.logging.info("Rewards: {}".format(rewards))
     bt.logging.info("Metrics: {}".format(metrics))

--- a/detection/validator/forward.py
+++ b/detection/validator/forward.py
@@ -74,6 +74,8 @@ async def forward(self):
 
     cnt_challenges_for_check = random.randint(1, min(10, len(texts)))
     check_ids = np.random.choice(np.arange(len(texts)).astype(int), size=cnt_challenges_for_check, replace=False)
+    texts = np.array(texts)
+
     check_responses = await get_all_responses(self, axons, texts[check_ids], self.config.neuron.timeout)
     all_responses = await get_all_responses(self, axons, texts, self.config.neuron.timeout)
 

--- a/detection/validator/forward.py
+++ b/detection/validator/forward.py
@@ -74,9 +74,8 @@ async def forward(self):
 
     cnt_challenges_for_check = random.randint(1, min(10, len(texts)))
     check_ids = np.random.choice(np.arange(len(texts)).astype(int), size=cnt_challenges_for_check, replace=False)
-    texts = np.array(texts)
 
-    check_responses = await get_all_responses(self, axons, texts[check_ids], self.config.neuron.timeout)
+    check_responses = await get_all_responses(self, axons, [texts[idx] for idx in check_ids], self.config.neuron.timeout)
     all_responses = await get_all_responses(self, axons, texts, self.config.neuron.timeout)
 
     rewards, metrics = get_rewards(self, labels=labels, responses=all_responses, check_responses=check_responses, check_ids=check_ids)

--- a/detection/validator/reward.py
+++ b/detection/validator/reward.py
@@ -52,7 +52,7 @@ def reward(y_pred: np.array, y_true: np.array) -> float:
 def count_penalty(y_pred: np.array, check_predictions: np.array, check_ids: np.array) -> float:
     bad = np.any((y_pred < 0) | (y_pred > 1))
 
-    if (check_predictions != y_pred[check_ids]).any():
+    if (check_predictions.round(3) != y_pred[check_ids].round(3)).any():
         bad = 1
 
     return 0 if bad else 1

--- a/detection/validator/reward.py
+++ b/detection/validator/reward.py
@@ -52,7 +52,7 @@ def reward(y_pred: np.array, y_true: np.array) -> float:
 def count_penalty(y_pred: np.array, check_predictions: np.array, check_ids: np.array) -> float:
     bad = np.any((y_pred < 0) | (y_pred > 1))
 
-    if (check_predictions.round(3) != y_pred[check_ids].round(3)).any():
+    if (check_predictions.round(2) != y_pred[check_ids].round(2)).any():
         bad = 1
 
     return 0 if bad else 1

--- a/detection/validator/reward.py
+++ b/detection/validator/reward.py
@@ -49,15 +49,21 @@ def reward(y_pred: np.array, y_true: np.array) -> float:
     return reward, res
 
 
-def count_penalty(y_pred: np.array) -> float:
+def count_penalty(y_pred: np.array, check_predictions: np.array, check_ids: np.array) -> float:
     bad = np.any((y_pred < 0) | (y_pred > 1))
+
+    if (check_predictions != y_pred[check_ids]).any():
+        bad = 1
+
     return 0 if bad else 1
 
     
 def get_rewards(
     self,
-    labels: torch.FloatTensor,
+    labels: np.array,
     responses: List[TextSynapse],
+    check_responses: List[TextSynapse],
+    check_ids: np.array
 ) -> torch.FloatTensor:
     """
     Returns a tensor of rewards for the given query and responses.
@@ -71,19 +77,23 @@ def get_rewards(
     """
     # Get all the reward results by iteratively calling your reward() function.
     predictions_list = [synapse.predictions for synapse in responses]
+    check_predictions_list = [synapse.predictions for synapse in check_responses]
 
     rewards = []
     metrics = []
     for uid in range(len(predictions_list)):
         try:
-            if not predictions_list[uid] or len(predictions_list[uid]) != len(labels):
+            if not predictions_list[uid] or len(predictions_list[uid]) != len(labels) or \
+                    not check_predictions_list[uid] or len(check_predictions_list[uid]) != len(check_ids):
                 rewards.append(0)
                 metrics.append({'fp_score': 0, 'f1_score': 0, 'ap_score': 0, 'penalty': 1})
                 continue
 
             predictions_array = np.array(predictions_list[uid])
+            check_predictions_array = np.array(check_predictions_list[uid])
+
             miner_reward, metric = reward(predictions_array, labels)
-            penalty = count_penalty(predictions_array)
+            penalty = count_penalty(predictions_array, check_predictions_array, check_ids)
             miner_reward *= penalty
             rewards.append(miner_reward)
             metric['penalty'] = penalty

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==6.12.2
+bittensor==6.9.3
 datasets==2.18.0
 langchain_community==0.0.27
 loguru==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==6.9.3
+bittensor==6.12.2
 datasets==2.18.0
 langchain_community==0.0.27
 loguru==0.7.0


### PR DESCRIPTION
We recently released API service and website, where we query miners, but as for now we have to query them by batches with 300 samples, so that their logic and predictions stay the same as during validation.

So, to be able to send small requests without worrying that miners logic will differ for them, we adjusted our penalty mechanism. Now, before sending 300 samples validators sends small batches with 1-10 samples, which are subsamples of those 300 samples. If miners predictions for 1-10 samples doesn't match predictions, that miner made for these texts during processing 300 samples, it will get zero reward for this iteration.