### PR TITLE
run.sh pm2 python --interpreter flag

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,7 @@ args=()
 version_location="./detection/__init__.py"
 version="__version__"
 delay=0 # Default delay value in hours
+interpreter="python3" # Default interpreter
 
 old_args=$@
 
@@ -164,6 +165,10 @@ while [[ $# -gt 0 ]]; do
           delay=$(($2 * 3600))
           shift 2
           ;;
+        --interpreter) # Handle interpreter argument
+          interpreter="$2"
+          shift 2
+          ;;
         *)
           # Add '=' sign between flag and value
           args+=("'$arg'")
@@ -220,7 +225,7 @@ echo "module.exports = {
   apps : [{
     name   : '$proc_name',
     script : '$script',
-    interpreter: 'python3',
+    interpreter: '$interpreter',
     min_uptime: '5m',
     max_restarts: '5',
     args: [$joined_args]


### PR DESCRIPTION
Pass custom python interpreter path so that run.sh will use it for the pm2 command.

```sh
cd ~/llm-detection

. venv/bin/activate

pm2 start ./run.sh --name llm_detection_validators_autoupdate  -- \
  --netuid 32 \
  --subtensor.network finney \
  --wallet.name muv \
  --wallet.hotkey muv \
  --logging.debug \
  --logging.trace \
  --neuron.device cuda:0 \
  --axon.port 50032 \
  --interpreter ./venv/bin/python
```

![image](https://github.com/user-attachments/assets/332e7ff5-a7bf-4f2a-86d7-7d41b736fed2)
