### PR TITLE
Fix wrong index for out-of-domain F1 score lookup

### DIFF
--- a/detection/validator/reward.py
+++ b/detection/validator/reward.py
@@ -138,7 +138,7 @@ def get_rewards(
             rewards.append(miner_reward)
             metric['penalty'] = penalty
             metric['out_of_domain_f1_score'] = out_of_domain_metric['f1_score']
-            metric['weighted_out_of_domain_f1_score'] = self.out_of_domain_f1_scores[i]
+            metric['weighted_out_of_domain_f1_score'] = self.out_of_domain_f1_scores[uid]
             metric['enough_stake'] = self.has_enough_stake[uid].item()
             metrics.append(metric)
         except Exception as e:


### PR DESCRIPTION
  **Clarification:** After deeper review, this bug only affects the **logged metric** (`metric['weighted_out_of_domain_f1_score']`), not the actual penalty calculation.

     - Line 131: `self.out_of_domain_f1_scores[uid]` — **correctly uses `uid`** for the EMA update
     - Line 134: `self.out_of_domain_f1_scores[uid] < 0.9` — **correctly uses `uid`** for the penalty check
     - Line 141: `self.out_of_domain_f1_scores[i]` — **bug: uses loop index `i`** for the W&B log

     So the penalty=0 decision is correct — miners are NOT penalized based on another miner's OOD score. However, the W&B logged value shows the **wrong miner's** weighted OOD F1, which makes debugging very confusing when trying to understand why a miner got penalty=0.

     Still worth fixing for observability — wrong metrics in W&B make it hard to diagnose scoring issues