### PR TITLE
Fix missing space at text concatenation boundaries

### DIFF
--- a/detection/validator/data_generator.py
+++ b/detection/validator/data_generator.py
@@ -130,8 +130,9 @@ def regenerated_in_the_middle(model: OllamaModel, text, summary_prompt, generati
         {"role": "system", "content": generation_prompt + f" The middle should be about {middle_size} words long"},
         {"role": "user", "content": f"begin: {begin}\nend: {end}\nsummary: {summary}"}
     ])
-    labels = [0] * len(begin.split()) + [1] * len(generated_middle.strip().split()) + [0] * len(end.split())
-    return begin + generated_middle.strip() + end, labels
+    generated_middle_stripped = generated_middle.strip()
+    labels = [0] * len(begin.split()) + [1] * len(generated_middle_stripped.split()) + [0] * len(end.split())
+    return begin + ' ' + generated_middle_stripped + ' ' + end, labels
 
 
 class DataGenerator:


### PR DESCRIPTION
When concatenating begin + generated_middle + end, no space separator was added. If begin doesn't end with whitespace and generated_middle doesn't start with one, words fuse together causing label misalignment.

Fix: Add explicit space separators between the three segments.

Example:
  begin = "The quick brown fox"
  generated_middle = "jumped over the lazy"
  end = "dog in the park."

  Before (BUG):
    "The quick brown foxjumped over the lazydog in the park."
    split() -> 10 words, but labels has 12 entries (4+5+3 from each part)

  After (FIX):
    "The quick brown fox jumped over the lazy dog in the park."
    split() -> 12 words, matches labels exactly