### PR TITLE
Fix empty word from truncation in subsample_words

### DIFF
--- a/detection/validator/segmentation_processer.py
+++ b/detection/validator/segmentation_processer.py
@@ -71,12 +71,12 @@ class SegmentationProcesser:
         res = words[ind:ind + cnt]
         labels = labels[ind:ind + cnt]
 
-        if random.random() > 0.5 and len(res):
-            sent_ind = random.randint(0, len(res[0]) - 1)
+        if random.random() > 0.5 and len(res) and len(res[0]) > 1:
+            sent_ind = random.randint(0, len(res[0]) - 2)
             res[0] = res[0][sent_ind:]
 
-        if random.random() > 0.5:
-            sent_ind = random.randint(0, len(res[-1]) - 1)
+        if random.random() > 0.5 and len(res) and len(res[-1]) > 1:
+            sent_ind = random.randint(1, len(res[-1]) - 1)
             res[-1] = res[-1][:sent_ind]
 
         return ' '.join(res), labels


### PR DESCRIPTION
The random word truncation at boundaries could produce empty strings:
- Last word: res[-1][:0] produces "" when sent_ind=0, causing label misalignment after split() skips the empty token.

Fix: Guard against single-char words and ensure slicing always produces at least 1 character.

Example:
  res = ["Hello", "world", "AI"]

  Before (BUG) - last word truncation:
    sent_ind = random.randint(0, len("AI")-1) = 0
    res[-1] = "AI"[:0] = ""
    ' '.join(["Hello", "world", ""]) = "Hello world "
    "Hello world ".split() = ["Hello", "world"]  # 2 words, but 3 labels!

  After (FIX):
    sent_ind = random.randint(1, len("AI")-1) = 1
    res[-1] = "AI"[:1] = "A"
    ' '.join(["Hello", "world", "A"]) = "Hello world A"  # 3 words, 3 labels