### PR TITLE
Fix synapse variable shadowing in dendrite_with_retries

### DIFF
--- a/detection/validator/forward.py
+++ b/detection/validator/forward.py
@@ -53,16 +53,16 @@ async def dendrite_with_retries(dendrite: bt.Dendrite, axons: list, synapse: Tex
 
         new_idx = []
         new_axons = []
-        for i, synapse in enumerate(responses):
-            if synapse.dendrite.status_code is not None and int(synapse.dendrite.status_code) == 422:
+        for i, resp in enumerate(responses):
+            if resp.dendrite.status_code is not None and int(resp.dendrite.status_code) == 422:
                 if attempt == cnt_attempts - 1:
-                    res[idx[i]] = synapse
+                    res[idx[i]] = resp
                     bt.logging.info("Wasn't able to get answers from axon {} after 3 attempts".format(axons[i]))
                 else:
                     new_idx.append(idx[i])
                     new_axons.append(axons[i])
             else:
-                res[idx[i]] = synapse
+                res[idx[i]] = resp
 
         if len(new_idx):
             bt.logging.info('Found {} synapses with broken pipe, retrying them'.format(len(new_idx)))


### PR DESCRIPTION
The loop variable synapse shadows the function parameter synapse. On retry attempts, the original query is lost and replaced with the last response from the previous iteration.

Fix: Rename loop variable from synapse to resp.

Example:
- Before: synapse param gets overwritten by loop
  for i, synapse in enumerate(responses):  # overwrites param!
- 2nd retry: synapse is now responses[-1], not original query

- After: param preserved
  for i, resp in enumerate(responses):  # param intact
-  2nd retry: synapse is still the original query