### PR TITLE
Remove debug prints from SynonymAttack.attack()

### DIFF
--- a/detection/attacks/synonym.py
+++ b/detection/attacks/synonym.py
@@ -9,9 +9,7 @@ import nltk
 import torch
 import transformers
 from sklearn.metrics.pairwise import cosine_similarity
-import torch, sys
-import pydantic
-import pydantic_core
+import torch
 
 
 class SynonymAttack:
@@ -109,14 +107,6 @@ class SynonymAttack:
         return max(candidates, key=lambda x: x["score"], default=None)
 
     def attack(self, text, labels):
-        print("torch.__version__:", torch.__version__)
-        print("torch.version.cuda:", torch.version.cuda)
-        print("torch.__file__:", torch.__file__)
-        if torch.cuda.is_available():
-            print("gpu:", torch.cuda.get_device_name(0))
-            print("capability:", torch.cuda.get_device_capability(0))
-        print(f"Pydantic version: {pydantic.__version__}")
-        print(f"Pydantic Core version: {pydantic_core.__version__}")
         cnt_human_chars = sum([len(word) + 1 for i, word in enumerate(text.split()) if not labels[i]])
         # Get spans for the words in the text from NLTK
         # e.g. "Hi my name is" -> [(0, 2), (3, 5), (6, 10), (11, 13)]


### PR DESCRIPTION
Debug prints dumping torch version, CUDA info, and pydantic versions run on every synonym attack call. These are noisy in production and leak environment details unnecessarily.

Removed prints:
  print("torch.__version__:", torch.__version__)
  print("torch.version.cuda:", torch.version.cuda)
  print("torch.__file__:", torch.__file__)
  print("gpu:", torch.cuda.get_device_name(0))
  print("capability:", torch.cuda.get_device_capability(0))
  print(f"Pydantic version: {pydantic.__version__}")
  print(f"Pydantic Core version: {pydantic_core.__version__}")

Also removed unused imports: sys, pydantic, pydantic_core.