### PR TITLE
Fix label length drift after augmentation

### DIFF
--- a/detection/attacks/data_augmentation.py
+++ b/detection/attacks/data_augmentation.py
@@ -52,9 +52,13 @@ class DataAugmentator:
                     last_zeros += 1
                 else:
                     break
-            new_first_zeros = int(n_auged * first_zeros / len(labels))
-            new_last_zeros = int(n_auged * last_zeros / len(labels))
+            new_first_zeros = round(n_auged * first_zeros / len(labels))
+            new_last_zeros = round(n_auged * last_zeros / len(labels))
+            # Clamp so the three segments always sum to exactly n_auged
             new_middle_ones = n_auged - new_first_zeros - new_last_zeros
+            if new_middle_ones < 0:
+                new_last_zeros = n_auged - new_first_zeros
+                new_middle_ones = 0
             labels_auged = [0] * new_first_zeros + [1] * new_middle_ones + [0] * new_last_zeros
 
         return text, applied_augs, labels_auged


### PR DESCRIPTION
Using int() truncation on both first_zeros and last_zeros could lose labels, making len(labels_auged) != n_auged.

Fix: Use round() instead of int() for proportional mapping, and add a clamp to guarantee the three segments always sum to n_auged.

Example:
  labels = [0,0,0,0,1,1,1,0,0,0], n_auged = 7
  int(7 * 4/10) = 2, int(7 * 3/10) = 2 -> middle = 3, total = 7 (lucky)
  But edge cases with int() truncating both ends lose 1-2 labels.
  round() + clamping guarantees exact total every time.